### PR TITLE
feat: 프론트 상품리스트 페이지 구현

### DIFF
--- a/backend/sin/src/main/java/sin/sin/controller/EventController.java
+++ b/backend/sin/src/main/java/sin/sin/controller/EventController.java
@@ -2,24 +2,22 @@ package sin.sin.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sin.sin.dto.EventResponse;
 import sin.sin.service.EventService;
 
 @RestController
-@RequestMapping("/shop")
+@RequestMapping("/goods/event")
 @RequiredArgsConstructor
 public class EventController {
 
     private final EventService eventService;
 
-    @GetMapping("/goods/event")
-    public ResponseEntity<List<EventResponse>> findAllEvent(){
+    @GetMapping
+    public ResponseEntity<List<EventResponse>> findAllEvent() {
         List<EventResponse> events = eventService.findAllEvent();
 
         return ResponseEntity.ok()

--- a/backend/sin/src/main/java/sin/sin/controller/FindProductDetailsController.java
+++ b/backend/sin/src/main/java/sin/sin/controller/FindProductDetailsController.java
@@ -10,7 +10,7 @@ import sin.sin.dto.ProductDetails.ProductDetailsResponse;
 import sin.sin.service.FindProductDetailsService;
 
 @RestController
-@RequestMapping("/shop/goods/goods_view")
+@RequestMapping("/goods/goods_view")
 @RequiredArgsConstructor
 public class FindProductDetailsController {
 

--- a/backend/sin/src/main/java/sin/sin/controller/FreqQuestionController.java
+++ b/backend/sin/src/main/java/sin/sin/controller/FreqQuestionController.java
@@ -11,7 +11,7 @@ import sin.sin.dto.FreqQuestionResponse;
 import sin.sin.service.FreqQuestionService;
 
 @RestController
-@RequestMapping("/shop/service/faq")
+@RequestMapping("/service/faq")
 @RequiredArgsConstructor
 public class FreqQuestionController {
 

--- a/backend/sin/src/main/java/sin/sin/controller/NotificationController.java
+++ b/backend/sin/src/main/java/sin/sin/controller/NotificationController.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/shop/board")
+@RequestMapping("/board")
 public class NotificationController {
 
     private final NotificationService notificationService;

--- a/backend/sin/src/main/java/sin/sin/controller/ProductListController.java
+++ b/backend/sin/src/main/java/sin/sin/controller/ProductListController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/shop/goods/goods_list")
+@RequestMapping("/goods/goods_list")
 public class ProductListController {
     private final ProductListService productListService;
 

--- a/backend/sin/src/main/java/sin/sin/domain/product/Product.java
+++ b/backend/sin/src/main/java/sin/sin/domain/product/Product.java
@@ -33,14 +33,6 @@ public class Product {
 
     private String contentSummary;
 
-    //TODO : 주석 풀기
-
-    //    @Column(nullable = false)
-    private String thumbnailName;
-
-    //    @Column(nullable = false)
-    private String thumbnailPath;
-
     @Column(nullable = false)
     private int price;
 

--- a/backend/sin/src/main/java/sin/sin/domain/product/SearchProductRepository.java
+++ b/backend/sin/src/main/java/sin/sin/domain/product/SearchProductRepository.java
@@ -55,7 +55,7 @@ public class SearchProductRepository {
 
     JPAQuery<ProductListResponse> selectFromJoin() {
         return queryFactory.select(Projections.bean(ProductListResponse.class,
-                        product.name, product.productCode, product.price, product.productCategory,
+                        product.name, product.productCode, product.contentSummary, product.price, product.productCategory,
                         product.discountPercent, product.createdDate, product.status, productReview.count().intValue().as("reviewCount")))
                 .from(product)
                 .leftJoin(productReview).on(productReview.product.eq(product));

--- a/backend/sin/src/main/java/sin/sin/dto/ProductListResponse.java
+++ b/backend/sin/src/main/java/sin/sin/dto/ProductListResponse.java
@@ -17,6 +17,7 @@ public class ProductListResponse {
     private String name;
     private String productCode;
     private String imageUrl;
+    private String contentSummary;
     private int price;
     private ProductCategory productCategory;
     private int discountPercent;

--- a/backend/sin/src/main/resources/application.properties
+++ b/backend/sin/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.servlet.context-path=/shop
+
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 

--- a/frontend/sin/.idea/codeStyles/Project.xml
+++ b/frontend/sin/.idea/codeStyles/Project.xml
@@ -1,0 +1,563 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="100" />
+    <AndroidXmlCodeStyleSettings>
+      <option name="USE_CUSTOM_SETTINGS" value="true" />
+      <option name="LAYOUT_SETTINGS">
+        <value>
+          <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false" />
+        </value>
+      </option>
+    </AndroidXmlCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
+      <option name="INDENT_CHAINED_CALLS" value="false" />
+    </JSCodeStyleSettings>
+    <JavaCodeStyleSettings>
+      <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
+    <Objective-C>
+      <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
+      <option name="INDENT_C_STRUCT_MEMBERS" value="2" />
+      <option name="INDENT_CLASS_MEMBERS" value="2" />
+      <option name="INDENT_VISIBILITY_KEYWORDS" value="1" />
+      <option name="INDENT_INSIDE_CODE_BLOCK" value="2" />
+      <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
+      <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
+      <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
+      <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
+      <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true" />
+      <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false" />
+      <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false" />
+    </Objective-C>
+    <Objective-C-extensions>
+      <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
+      <option name="RELEASE_STYLE" value="IVAR" />
+      <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
+      <file>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+      </file>
+      <class>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+      </class>
+      <extensions>
+        <pair source="cc" header="h" />
+        <pair source="c" header="h" />
+      </extensions>
+    </Objective-C-extensions>
+    <Python>
+      <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true" />
+    </Python>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="INDENT_CHAINED_CALLS" value="false" />
+    </TypeScriptCodeStyleSettings>
+    <XML>
+      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
+    </XML>
+    <codeStyleSettings language="CSS">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="ECMA Script Level 4">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    </codeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="WRAP_COMMENTS" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="RIGHT_MARGIN" value="80" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="ObjectiveC">
+      <option name="RIGHT_MARGIN" value="80" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="BLANK_LINES_BEFORE_IMPORTS" value="0" />
+      <option name="BLANK_LINES_AFTER_IMPORTS" value="0" />
+      <option name="BLANK_LINES_AROUND_CLASS" value="0" />
+      <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="PROTO">
+      <option name="RIGHT_MARGIN" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Python">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="RIGHT_MARGIN" value="80" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="SASS">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="SCSS">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:.*Style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_width</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_height</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_weight</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_margin</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginTop</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginBottom</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginStart</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginEnd</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginLeft</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_marginRight</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:padding</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingTop</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingBottom</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingStart</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingEnd</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingLeft</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:paddingRight</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/tools</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="protobuf">
+      <option name="RIGHT_MARGIN" value="80" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/frontend/sin/.idea/codeStyles/codeStyleConfig.xml
+++ b/frontend/sin/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="GoogleStyle" />
+  </state>
+</component>

--- a/frontend/sin/.idea/runConfigurations.xml
+++ b/frontend/sin/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/frontend/sin/src/App.js
+++ b/frontend/sin/src/App.js
@@ -5,7 +5,6 @@ import Header from './components/Header';
 import Home from './components/Home';
 import Event from './components/event/Event';
 import Shoppinglist from './components/Shoppinglist';
-import List from './components/List';
 import Item from './components/Item';
 import Signup from './components/Signup';
 import Login from './components/Login';
@@ -14,6 +13,7 @@ import Notice from './components/Notice';
 import Footer from './components/Footer';
 import Noticepage from './components/Noticepage';
 import NonProductEvent from "./components/event/NonProductEvent";
+import ProductList from "./components/products/ProductList";
 
 const GlobalStyle = createGlobalStyle`
 * {padding: 0; margin: 0;}
@@ -35,7 +35,7 @@ function App() {
     <Route path='/shop/main/event' exact component={NonProductEvent} />
     <Route path='/shop/goods/event' exact component={Event} />
     <Route path='/shop/goods/goods_cart' exact component={Shoppinglist} />
-    <Route path='/shop/goods/goods_list' exact component={List} />
+    <Route path='/shop/goods/goods_list' exact component={ProductList} />
     <Route path='/shop/goods/goods_view' exact component={Item} />
     <Route path='/shop/member/join' exact component={Signup} />
     <Route path='/shop/member/login' exact component={Login} />

--- a/frontend/sin/src/components/Mypage.js
+++ b/frontend/sin/src/components/Mypage.js
@@ -27,7 +27,6 @@ const Mainleftli = styled.li`padding: 15px 0 15px 20px; border: 1px solid #dbdbd
 const Mainright = styled.div`width: 80%;`
 const Mypage = ({match}) => {
     const type = match.params.mypageparams
-    console.log(type)
     return(
         <>
         <Mypageuserinfowrap>

--- a/frontend/sin/src/components/api/GetNoticeApi.js
+++ b/frontend/sin/src/components/api/GetNoticeApi.js
@@ -4,7 +4,7 @@ import { BACKEND_ADDRESS } from '../../constants/ADDRESS';
 
 const GetNoticeApi = (page) => {
     return (
-        axios.get(BACKEND_ADDRESS+`/shop/board/list?id=notice&page=`+page)
+        axios.get(BACKEND_ADDRESS+`/board/list?id=notice&page=`+page)
     )
 }
 

--- a/frontend/sin/src/components/api/GetSearchedNoticeApi.js
+++ b/frontend/sin/src/components/api/GetSearchedNoticeApi.js
@@ -4,7 +4,7 @@ import { BACKEND_ADDRESS } from '../../constants/ADDRESS';
 
 const GetSearchedNoticeApi = (url,word,page) => {
     return (
-        axios.get(BACKEND_ADDRESS+`/shop/board/list?id=notice`+url+`&word=`+word+`&page=`+page)
+        axios.get(BACKEND_ADDRESS+`/board/list?id=notice`+url+`&word=`+word+`&page=`+page)
     )
 }
 

--- a/frontend/sin/src/components/event/FindEventsApi.js
+++ b/frontend/sin/src/components/event/FindEventsApi.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
 
 const findEventsApi = () => {
-  return (axios.get(BACKEND_ADDRESS + "/shop/goods/event")
+  return (axios.get(BACKEND_ADDRESS + "/goods/event")
   .then(response => response.data))
 };
 

--- a/frontend/sin/src/components/event/FindNonProductEventsApi.js
+++ b/frontend/sin/src/components/event/FindNonProductEventsApi.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
 
 const findNonProductEventsApi = (name) => {
-  return (axios.get(BACKEND_ADDRESS + "/shop/main/event?name="+name)
+  return (axios.get(BACKEND_ADDRESS + "/main/event?name="+name)
   .then(response => response.data))
 };
 

--- a/frontend/sin/src/components/notice/FindFaqApi.js
+++ b/frontend/sin/src/components/notice/FindFaqApi.js
@@ -3,8 +3,8 @@ import axios from "axios";
 import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
 const findFaqApi = (page) => {
 
-  return page?(axios.get(BACKEND_ADDRESS + "/shop/service/faq?page="+page)
-  .then(response => response.data)) : (axios.get(BACKEND_ADDRESS + "/shop/service/faq")
+  return page?(axios.get(BACKEND_ADDRESS + "/service/faq?page="+page)
+  .then(response => response.data)) : (axios.get(BACKEND_ADDRESS + "/service/faq")
   .then(response => response.data))
 };
 

--- a/frontend/sin/src/components/notice/FindTotalFaqsApi.js
+++ b/frontend/sin/src/components/notice/FindTotalFaqsApi.js
@@ -4,7 +4,7 @@ import axios from "axios";
 
 const findTotalFaqsApi = () => {
 
-  return (axios.get(BACKEND_ADDRESS + "/shop/service/faq/total")
+  return (axios.get(BACKEND_ADDRESS + "/service/faq/total")
   .then(response => response.data))
 };
 

--- a/frontend/sin/src/components/products/FindProductListApi.js
+++ b/frontend/sin/src/components/products/FindProductListApi.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
+
+const FindProductListApi = (category) => {
+  return (axios.get(BACKEND_ADDRESS + "/goods/goods_list?category=" + category)
+  .then(response => response.data))
+};
+
+export default FindProductListApi;

--- a/frontend/sin/src/components/products/FindProductListApi.js
+++ b/frontend/sin/src/components/products/FindProductListApi.js
@@ -2,9 +2,9 @@ import React from 'react';
 import axios from "axios";
 import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
 
-const FindProductListApi = (category) => {
-  return (axios.get(BACKEND_ADDRESS + "/goods/goods_list?category=" + category)
-  .then(response => response.data))
+const findProductListApi = (category, list) => {
+  return category ? axios.get(BACKEND_ADDRESS + "/goods/goods_list?category=" + category).then(response => response.data)
+      : axios.get(BACKEND_ADDRESS + "/goods/goods_list?list=" + list).then(response => response.data);
 };
 
-export default FindProductListApi;
+export default findProductListApi;

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from "styled-components";
+
+const ProductsListWrap = styled.div`
+  width: 1050px;
+  margin: 0 auto;
+  border: 2px solid rgb(90, 155, 213);
+  padding: 10px;
+`;
+const Container = styled.div`
+  display: inline-block;
+  width: 320px;
+  margin:11px;
+  height: 500px;
+  border: 2px solid rgb(90, 155, 213);
+`;
+
+const ProductList = () => {
+  return (
+      <ProductsListWrap>
+        <Container>ㅎㅇㅎㅇ</Container>
+        <Container>ㅎㅇㅎㅇ</Container>
+        <Container>ㅎㅇㅎㅇ</Container>
+        <Container>ㅎㅇㅎㅇ</Container>
+        <Container>ㅎㅇㅎㅇ</Container>
+        <Container>ㅎㅇㅎㅇ</Container>
+        <Container>ㅎㅇㅎㅇ</Container>
+      </ProductsListWrap>
+  );
+};
+
+export default ProductList;

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -20,9 +20,20 @@ const ProductImg = styled.img`
   display: inline-block;
   width: 320px;
   height: 400px;
- 
 `;
-
+const ProductName = styled.div`
+`;
+const ProductDiscountPercent = styled.div`
+  display: inline-block;
+`;
+const ProductPrevPrice = styled.div`
+  display: inline-block;
+  margin-left:10px;
+`;
+const ProductPrice = styled.div`
+`;
+const ProductSummary = styled.div`
+`;
 const ProductList = (props) => {
   const category = queryString.parse(props.location.search).category;
   const list = queryString.parse(props.location.search).list;
@@ -36,7 +47,14 @@ const ProductList = (props) => {
   },[category, list]);
 
   const productLists = products ? products.map((product)=>{
-    return <Container><ProductImg src= {product.imageUrl} /></Container>;
+    return <Container>
+             <ProductImg src= {product.imageUrl} />
+             <ProductName>{product.name}</ProductName>
+             <ProductDiscountPercent>{product.discountPercent}</ProductDiscountPercent>
+             <ProductPrevPrice>{product.price}</ProductPrevPrice>
+             <ProductPrice>할인적용가격</ProductPrice>
+             <ProductSummary>{product.contentSummary}</ProductSummary>
+           </Container>;
   }) : "";
 
 console.log(products)

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import styled from "styled-components";
-import FindProductListApi from "./FindProductListApi";
+import findProductListApi from "./FindProductListApi";
 import queryString from "query-string";
 
 const ProductsListWrap = styled.div`
@@ -25,14 +25,15 @@ const ProductImg = styled.img`
 
 const ProductList = (props) => {
   const category = queryString.parse(props.location.search).category;
-
+  const list = queryString.parse(props.location.search).list;
   const [products,setProducts] = useState(null);
 
   useEffect(()=> {
-    FindProductListApi(category).then(prodictPromises => {
+    setProducts(null)
+    findProductListApi(category, list).then(prodictPromises => {
       setProducts(prodictPromises)
     });
-  },[]);
+  },[category, list]);
 
   const productLists = products ? products.map((product)=>{
     return <Container><ProductImg src= {product.imageUrl} /></Container>;

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import styled from "styled-components";
+import FindProductListApi from "./FindProductListApi";
+import queryString from "query-string";
 
 const ProductsListWrap = styled.div`
   width: 1050px;
@@ -15,7 +17,17 @@ const Container = styled.div`
   border: 2px solid rgb(90, 155, 213);
 `;
 
-const ProductList = () => {
+const ProductList = (props) => {
+  const category = queryString.parse(props.location.search).category;
+
+  const [products,setProducts] = useState(null);
+
+  useEffect(()=> {
+    FindProductListApi(category).then(prodictPromises => {
+      setProducts(prodictPromises)
+    });
+  },[]);
+
   return (
       <ProductsListWrap>
         <Container>ㅎㅇㅎㅇ</Container>

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -71,9 +71,9 @@ const ProductList = (props) => {
              <ProductDetails>
                <ProductName>{product.name}</ProductName>
                <ProductDiscountPercent>{product.discountPercent}%</ProductDiscountPercent>
-               <ProductPrice>{product.price * (1-product.discountPercent/100)}원</ProductPrice>
+               <ProductPrice>{Math.floor(product.price * (1-product.discountPercent/100))}원</ProductPrice>
                <ProductPrevPrice>{product.price}원</ProductPrevPrice>
-               <ProductSummary>{product.contentSummary?product.contentSummary: "상품요약정보"}</ProductSummary>
+               <ProductSummary>{product.contentSummary ? product.contentSummary : "상품요약정보"}</ProductSummary>
              </ProductDetails>
            </Container>;
   }) : "";

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -82,6 +82,7 @@ const ProductList = (props) => {
   return (
       <ProductsListWrap>
         <Sort
+          products={products}
           category={category}
         />
         {productLists}

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -16,6 +16,12 @@ const Container = styled.div`
   height: 500px;
   border: 2px solid rgb(90, 155, 213);
 `;
+const ProductImg = styled.img`
+  display: inline-block;
+  width: 320px;
+  height: 400px;
+ 
+`;
 
 const ProductList = (props) => {
   const category = queryString.parse(props.location.search).category;
@@ -28,15 +34,14 @@ const ProductList = (props) => {
     });
   },[]);
 
+  const productLists = products ? products.map((product)=>{
+    return <Container><ProductImg src= {product.imageUrl} /></Container>;
+  }) : "";
+
+console.log(products)
   return (
       <ProductsListWrap>
-        <Container>ㅎㅇㅎㅇ</Container>
-        <Container>ㅎㅇㅎㅇ</Container>
-        <Container>ㅎㅇㅎㅇ</Container>
-        <Container>ㅎㅇㅎㅇ</Container>
-        <Container>ㅎㅇㅎㅇ</Container>
-        <Container>ㅎㅇㅎㅇ</Container>
-        <Container>ㅎㅇㅎㅇ</Container>
+        {productLists}
       </ProductsListWrap>
   );
 };

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -6,34 +6,53 @@ import queryString from "query-string";
 const ProductsListWrap = styled.div`
   width: 1050px;
   margin: 0 auto;
-  border: 2px solid rgb(90, 155, 213);
   padding: 10px;
 `;
 const Container = styled.div`
+  position: relative;
   display: inline-block;
   width: 320px;
   margin:11px;
   height: 500px;
-  border: 2px solid rgb(90, 155, 213);
+  cursor: pointer;
 `;
 const ProductImg = styled.img`
-  display: inline-block;
+  position: absolute;
   width: 320px;
-  height: 400px;
+  height: 340px;
 `;
+
+const ProductDetails = styled.div`
+  position: absolute;
+  top: 350px;
+`;
+
 const ProductName = styled.div`
+  font-size: 25px;
 `;
+
 const ProductDiscountPercent = styled.div`
   display: inline-block;
+  font-size: 20px;
+  color: red;
+  font-weight: bold;
 `;
-const ProductPrevPrice = styled.div`
-  display: inline-block;
-  margin-left:10px;
-`;
+
 const ProductPrice = styled.div`
+  display: inline-block;
+  font-size: 20px;
+  margin-left:10px;
+  font-weight: bold;
 `;
+
+const ProductPrevPrice = styled.div`
+  color: gray;
+  text-decoration:line-through
+`;
+
 const ProductSummary = styled.div`
 `;
+
 const ProductList = (props) => {
   const category = queryString.parse(props.location.search).category;
   const list = queryString.parse(props.location.search).list;
@@ -49,11 +68,13 @@ const ProductList = (props) => {
   const productLists = products ? products.map((product)=>{
     return <Container>
              <ProductImg src= {product.imageUrl} />
-             <ProductName>{product.name}</ProductName>
-             <ProductDiscountPercent>{product.discountPercent}</ProductDiscountPercent>
-             <ProductPrevPrice>{product.price}</ProductPrevPrice>
-             <ProductPrice>할인적용가격</ProductPrice>
-             <ProductSummary>{product.contentSummary}</ProductSummary>
+             <ProductDetails>
+               <ProductName>{product.name}</ProductName>
+               <ProductDiscountPercent>{product.discountPercent}%</ProductDiscountPercent>
+               <ProductPrice>{product.price * (1-product.discountPercent/100)}원</ProductPrice>
+               <ProductPrevPrice>{product.price}원</ProductPrevPrice>
+               <ProductSummary>{product.contentSummary?product.contentSummary: "상품요약정보"}</ProductSummary>
+             </ProductDetails>
            </Container>;
   }) : "";
 

--- a/frontend/sin/src/components/products/ProductList.js
+++ b/frontend/sin/src/components/products/ProductList.js
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import styled from "styled-components";
 import findProductListApi from "./FindProductListApi";
 import queryString from "query-string";
+import Sort from "./Sort";
 
 const ProductsListWrap = styled.div`
   width: 1050px;
@@ -78,9 +79,11 @@ const ProductList = (props) => {
            </Container>;
   }) : "";
 
-console.log(products)
   return (
       <ProductsListWrap>
+        <Sort
+          category={category}
+        />
         {productLists}
       </ProductsListWrap>
   );

--- a/frontend/sin/src/components/products/Sort.js
+++ b/frontend/sin/src/components/products/Sort.js
@@ -1,89 +1,41 @@
 import React,{useEffect, useState} from 'react';
 import styled from 'styled-components';
-import query from 'query-string';
-import axios from 'axios';
-import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
 
 const Listwrap = styled.div`margin-top: 50px;`
-const Container = styled.div`width:1050px; margin: 0 auto;`
+const Container = styled.div`width:1050px; margin: 0 auto; border: 2px solid rgb(90, 155, 213);`
 const Row = styled.div``
-
-const Item = styled.div`border: 1px solid #black; width: 32%; height: 450px; padding: 10px; margin: 10px; &:hover{cursor: pointer;}`
-const Itemimg = styled.div`height: 75%; background: #999; transition: 0.3s all ease-in; &:hover {background: #fff;}`
-const Itemname = styled.div`height: 7%; margin-top:10px; background: #888;`
-const Itemprice = styled.div`height: 7%; background: #777;`
-const Itemdesc = styled.div`height: 7%; background: #666;`
-
 const Title = styled.div`margin-bottom: 20px;`
 const Nav = styled.div`position: relative;`
 const Navtype = styled.span`font-size:14px; font-weight: bold; padding-left: 10px; color: #5f0080;`
 const Category = styled.p`font-weight: bold;`
 const Orderby = styled.button` float: right; border: none; background: none; cursor: pointer;`
-const Orderbylistul = styled.ul`position: absolute; display: none; width: 100%; top: 30px; right: -10px; width: 90px; text-align: right; box-shadow: 0 2px 4px rgb(0 0 0 / 30%)`
+const Orderbylistul = styled.ul`position: absolute; display: none; width: 100%; top: 30px; right: -10px; width: 90px; text-align: right; box-shadow: 0 2px 4px rgb(0 0 0 / 30%); background-color: white; z-index: 1`
 const Orderbylistli = styled.li`font-size: 12px; font-weight: bold; color: gray; padding: 10px 5px 10px 0; cursor: pointer; &:hover {color: #5f0080;}`
 
-const Sort = ({history,location}) => {
+const Sort = (category) => {
     const [selectedli,setSelectedli] = useState('')
-    const [pageinfo,setPageinfo] = useState({
-        kor:'',
-        orderby:''
-    })
-    const [items,setItems] = useState([])
-    
-    const category = query.parse(location.search).category
+    const [pageinfo,setPageinfo] = useState('')
 
     useEffect(()=>{
         document.getElementById('nav').childNodes.forEach(e => {e.style.color = 'gray'})
         if(!category) {
-            setPageinfo({
-                ...pageinfo,
-                kor: '알뜰쇼핑',
-                orderby: '혜택순'
-            })
+            setPageinfo('혜택순')
             document.getElementById('lifou').style.color = '#5f0080'
             setSelectedli('lifou')
-            axios.get(BACKEND_ADDRESS+'/shop/goods/goods_list?list=sale').then((res)=>{
-                items.concat(res)
-            })
         } else if(category==='038') {
-            setPageinfo({
-                ...pageinfo,
-                kor: '신상품',
-                orderby: '신상품순'
-            })
+            setPageinfo('신상품순')
             document.getElementById('litwo').style.color = '#5f0080'
             setSelectedli('litwo')
-            axios.get(BACKEND_ADDRESS+'/shop/goods/goods_list?category='+category).then((res)=>{
-                items.concat(res)
-            })
         } else if(category==='029') {
-            setPageinfo({
-                ...pageinfo,
-                kor: '베스트',
-                orderby: '추천순'
-            })
+            setPageinfo('추천순')
             document.getElementById('lione').style.color = '#5f0080'
             setSelectedli('lione')
-            axios.get(BACKEND_ADDRESS+'/shop/goods/goods_list?category='+category).then((res)=>{
-                items.concat(res)
-            })
         } else {
-            setPageinfo({
-                ...pageinfo,
-                kor: '카테고리',
-                orderby: '추천순'
-            })
+            setPageinfo( '추천순')
             document.getElementById('lione').style.color = '#5f0080'
             setSelectedli('lione')
-            axios.get(BACKEND_ADDRESS+'/shop/goods/goods_list?category='+category).then((res)=>{
-                items.concat(res)
-            })
         }
     },[category])
-
-    const link = (itemid) => {
-        history.push(`/shop/goods/goods_view?goodsno=${itemid}`)
-    }
 
     const togglenav = () => {
         const nav = document.getElementById('nav')
@@ -92,27 +44,38 @@ const Sort = ({history,location}) => {
     }
 
     const selectorderby = e => {
+        const nav = document.getElementById('nav');
+        nav.style.display='none';
         e.target.style.color = '#5f0080'
-        if(e.target.id === selectedli) {
-            console.log('same')
-        } else {
+        if(e.target.id != selectedli) {
+            if(e.target.id === 'lione')
+                setPageinfo('추천순')
+            if(e.target.id === 'litwo')
+                setPageinfo('신상품순')
+            if(e.target.id === 'lithr')
+                setPageinfo('인기상품순')
+            if(e.target.id === 'lifou')
+                setPageinfo('혜택순')
+            if(e.target.id === 'lifiv')
+                setPageinfo('낮은 가격순')
+            if(e.target.id === 'lisix')
+                setPageinfo('높은 가격순')
             document.getElementById(selectedli).style.color = 'gray'
             //이 식으로 색이 변화되면 기존 hover 시 색변화 css 미적용됨
             setSelectedli(e.target.id)
         }
     }
 
-
     return (
         <Listwrap>
             <Container>
                 <Row>
                     <Title>
-                        <Category>{pageinfo.kor}</Category>
+                        <Category>test</Category>
                     </Title>
                     <Nav>
                         <Navtype>전체보기</Navtype>
-                        <Orderby onClick={togglenav}>{pageinfo.orderby}</Orderby>
+                        <Orderby onClick={togglenav}>{pageinfo}</Orderby>
                         <Orderbylistul id='nav'>
                             <Orderbylistli id='lione' onClick={selectorderby}>추천순</Orderbylistli>
                             <Orderbylistli id='litwo' onClick={selectorderby}>신상품순</Orderbylistli>
@@ -122,17 +85,6 @@ const Sort = ({history,location}) => {
                             <Orderbylistli id='lisix' onClick={selectorderby}>높은 가격순</Orderbylistli>
                         </Orderbylistul>
                     </Nav>
-                    <ul>
-                        {items.map(item=><li onClick={()=>link('itemid')}>
-                            <Item>
-                                <Itemimg>{item.img}}</Itemimg>
-                                <Itemname>{item.title}</Itemname>
-                                <Itemprice>{item.price}</Itemprice>
-                                <Itemdesc>{item.desc}</Itemdesc>
-                            </Item>
-                        </li>
-                        )}
-                    </ul>
                 </Row>
             </Container>
         </Listwrap>

--- a/frontend/sin/src/components/products/Sort.js
+++ b/frontend/sin/src/components/products/Sort.js
@@ -2,7 +2,7 @@ import React,{useEffect, useState} from 'react';
 import styled from 'styled-components';
 import query from 'query-string';
 import axios from 'axios';
-import {BACKEND_ADDRESS} from "../constants/ADDRESS";
+import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
 
 const Listwrap = styled.div`margin-top: 50px;`
 const Container = styled.div`width:1050px; margin: 0 auto;`
@@ -22,7 +22,7 @@ const Orderby = styled.button` float: right; border: none; background: none; cur
 const Orderbylistul = styled.ul`position: absolute; display: none; width: 100%; top: 30px; right: -10px; width: 90px; text-align: right; box-shadow: 0 2px 4px rgb(0 0 0 / 30%)`
 const Orderbylistli = styled.li`font-size: 12px; font-weight: bold; color: gray; padding: 10px 5px 10px 0; cursor: pointer; &:hover {color: #5f0080;}`
 
-const List = ({history,location}) => {
+const Sort = ({history,location}) => {
     const [selectedli,setSelectedli] = useState('')
     const [pageinfo,setPageinfo] = useState({
         kor:'',
@@ -139,4 +139,4 @@ const List = ({history,location}) => {
     )
 }
 
-export default List;
+export default Sort;

--- a/frontend/sin/src/components/products/Sort.js
+++ b/frontend/sin/src/components/products/Sort.js
@@ -2,31 +2,31 @@ import React,{useEffect, useState} from 'react';
 import styled from 'styled-components';
 
 const Listwrap = styled.div`margin-top: 50px;`
-const Container = styled.div`width:1050px; margin: 0 auto; border: 2px solid rgb(90, 155, 213);`
+const Container = styled.div`width:1050px; margin: 0 auto;`
 const Row = styled.div``
 const Title = styled.div`margin-bottom: 20px;`
 const Nav = styled.div`position: relative;`
-const Navtype = styled.span`font-size:14px; font-weight: bold; padding-left: 10px; color: #5f0080;`
+const Navtype = styled.span`font-size:14px; font-weight: bold; padding-left: 10px; color: gray;`
 const Category = styled.p`font-weight: bold;`
-const Orderby = styled.button` float: right; border: none; background: none; cursor: pointer;`
+const Orderby = styled.button` float: right; border: none; background: none; cursor: pointer; color: gray`
 const Orderbylistul = styled.ul`position: absolute; display: none; width: 100%; top: 30px; right: -10px; width: 90px; text-align: right; box-shadow: 0 2px 4px rgb(0 0 0 / 30%); background-color: white; z-index: 1`
 const Orderbylistli = styled.li`font-size: 12px; font-weight: bold; color: gray; padding: 10px 5px 10px 0; cursor: pointer; &:hover {color: #5f0080;}`
 
-const Sort = (category) => {
+const Sort = (props) => {
     const [selectedli,setSelectedli] = useState('')
     const [pageinfo,setPageinfo] = useState('')
 
     useEffect(()=>{
         document.getElementById('nav').childNodes.forEach(e => {e.style.color = 'gray'})
-        if(!category) {
+        if(!props.category) {
             setPageinfo('혜택순')
             document.getElementById('lifou').style.color = '#5f0080'
             setSelectedli('lifou')
-        } else if(category==='038') {
+        } else if(props.category==='038') {
             setPageinfo('신상품순')
             document.getElementById('litwo').style.color = '#5f0080'
             setSelectedli('litwo')
-        } else if(category==='029') {
+        } else if(props.category==='029') {
             setPageinfo('추천순')
             document.getElementById('lione').style.color = '#5f0080'
             setSelectedli('lione')
@@ -35,7 +35,7 @@ const Sort = (category) => {
             document.getElementById('lione').style.color = '#5f0080'
             setSelectedli('lione')
         }
-    },[category])
+    },[props.category])
 
     const togglenav = () => {
         const nav = document.getElementById('nav')
@@ -74,7 +74,7 @@ const Sort = (category) => {
                         <Category>test</Category>
                     </Title>
                     <Nav>
-                        <Navtype>전체보기</Navtype>
+                        <Navtype>총 {props.products ? Object.keys(props.products).length : ""}건</Navtype>
                         <Orderby onClick={togglenav}>{pageinfo}</Orderby>
                         <Orderbylistul id='nav'>
                             <Orderbylistli id='lione' onClick={selectorderby}>추천순</Orderbylistli>

--- a/frontend/sin/src/constants/ADDRESS.js
+++ b/frontend/sin/src/constants/ADDRESS.js
@@ -1,2 +1,2 @@
-export const BACKEND_ADDRESS = "http://localhost:8080";
+export const BACKEND_ADDRESS = "http://localhost:8080/shop";
 export const FRONTEND_ADDRESS = "http://localhost:3000";


### PR DESCRIPTION
**이슈 번호**

resolved: #49 
**작업 내용**

1. 프론트 신상품, 베스트, 알뜰 쇼핑 페이지 구현
2. 상품정렬바 수정

![image](https://user-images.githubusercontent.com/45135492/134123722-e75995b5-ced2-4ea1-a5e0-4cfdfb361f2d.png)
![image](https://user-images.githubusercontent.com/45135492/134123740-00c07d1c-8c91-431e-8e1d-524766c1d703.png)
![image](https://user-images.githubusercontent.com/45135492/134123774-c5d7ad5e-6478-4680-ab9c-5ae2f129dc49.png)


**테스트 작성 여부**

- [ ] Test case

**주의 사항**

상품정렬 바는 틀만 구현됨. 버튼을 눌러지지만 정렬이 이뤄지지는 않음. 이후 새로 이슈파서 동작시킬 예정