### PR TITLE
feat: 프론트 로그인 관련 기능 구현

### DIFF
--- a/backend/sin/http/member.http
+++ b/backend/sin/http/member.http
@@ -1,0 +1,4 @@
+### 내 아이디, 로그인아이디 조회
+GET http://localhost:8080/shop/member/me
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjM2NDM2MzExLCJleHAiOjE2MzY1MjI3MTF9.2tyT2HjAK0wWeTaIZ9gl8pXwIgMM1Hh6vbKMDFCjGWguyyR9OF0LSirDRYr5N7lz3ZKDdEh0h8UMnmZC_BqM_g

--- a/backend/sin/src/main/java/sin/sin/config/auth/CurrentUser.java
+++ b/backend/sin/src/main/java/sin/sin/config/auth/CurrentUser.java
@@ -1,0 +1,16 @@
+package sin.sin.config.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentUser {
+
+}

--- a/backend/sin/src/main/java/sin/sin/controller/AuthController.java
+++ b/backend/sin/src/main/java/sin/sin/controller/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
     public ResponseEntity isDuplicateId(@RequestParam String id) {
         authService.isDuplicateId(id);
 
-        return ResponseEntity.ok("중복되지 않은 아이디입니다");
+        return ResponseEntity.ok("사용가능한 아이디입니다");
 
     }
 
@@ -49,7 +49,7 @@ public class AuthController {
     public ResponseEntity isDuplicateEmail(@RequestParam String email) {
         authService.isDuplicateEmail(email);
 
-        return ResponseEntity.ok("중복되지 않은 이메일입니다");
+        return ResponseEntity.ok("사용가능한 이메일입니다");
     }
 
 }

--- a/backend/sin/src/main/java/sin/sin/controller/ExceptionAdvice.java
+++ b/backend/sin/src/main/java/sin/sin/controller/ExceptionAdvice.java
@@ -1,0 +1,29 @@
+package sin.sin.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import sin.sin.dto.auth.ErrorResponse;
+import sin.sin.handler.exception.AlreadyExistedEmailException;
+import sin.sin.handler.exception.AlreadyExistedIdException;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(AlreadyExistedEmailException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyExistedEmailException(
+        AlreadyExistedEmailException e) {
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(AlreadyExistedIdException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyExistedIdException(
+        AlreadyExistedIdException e) {
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
+}

--- a/backend/sin/src/main/java/sin/sin/controller/ExceptionAdvice.java
+++ b/backend/sin/src/main/java/sin/sin/controller/ExceptionAdvice.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import sin.sin.dto.auth.ErrorResponse;
+import sin.sin.dto.ErrorResponse;
 import sin.sin.handler.exception.AlreadyExistedEmailException;
 import sin.sin.handler.exception.AlreadyExistedIdException;
 

--- a/backend/sin/src/main/java/sin/sin/controller/MemberController.java
+++ b/backend/sin/src/main/java/sin/sin/controller/MemberController.java
@@ -1,0 +1,27 @@
+package sin.sin.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sin.sin.config.auth.PrincipalDetails;
+import sin.sin.config.auth.CurrentUser;
+import sin.sin.dto.MemberResponse;
+import sin.sin.service.MemberService;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponse> findMember(@CurrentUser PrincipalDetails userDetails){
+        MemberResponse memberResponse = memberService.findMember(userDetails.getMember());
+
+        return ResponseEntity.ok()
+            .body(memberResponse);
+    }
+}

--- a/backend/sin/src/main/java/sin/sin/dto/ErrorResponse.java
+++ b/backend/sin/src/main/java/sin/sin/dto/ErrorResponse.java
@@ -1,4 +1,4 @@
-package sin.sin.dto.auth;
+package sin.sin.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/backend/sin/src/main/java/sin/sin/dto/MemberResponse.java
+++ b/backend/sin/src/main/java/sin/sin/dto/MemberResponse.java
@@ -12,4 +12,5 @@ public class MemberResponse {
 
     private Long memberId;
     private String loginId;
+    private int levelSalePercent;
 }

--- a/backend/sin/src/main/java/sin/sin/dto/MemberResponse.java
+++ b/backend/sin/src/main/java/sin/sin/dto/MemberResponse.java
@@ -1,0 +1,15 @@
+package sin.sin.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class MemberResponse {
+
+    private Long memberId;
+    private String loginId;
+}

--- a/backend/sin/src/main/java/sin/sin/dto/auth/ErrorResponse.java
+++ b/backend/sin/src/main/java/sin/sin/dto/auth/ErrorResponse.java
@@ -4,7 +4,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/backend/sin/src/main/java/sin/sin/dto/auth/ErrorResponse.java
+++ b/backend/sin/src/main/java/sin/sin/dto/auth/ErrorResponse.java
@@ -1,0 +1,15 @@
+package sin.sin.dto.auth;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class ErrorResponse {
+
+    private String message;
+}

--- a/backend/sin/src/main/java/sin/sin/service/MemberService.java
+++ b/backend/sin/src/main/java/sin/sin/service/MemberService.java
@@ -1,0 +1,23 @@
+package sin.sin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sin.sin.domain.member.Member;
+import sin.sin.domain.member.MemberRepository;
+import sin.sin.dto.MemberResponse;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberResponse findMember(Member member) {
+        Member foundMember = memberRepository.findById(member.getId())
+            .orElseThrow(() -> new IllegalArgumentException("해당되는 유저가 없습니다!"));
+
+        return new MemberResponse(foundMember.getId(), foundMember.get_id());
+    }
+}

--- a/backend/sin/src/main/java/sin/sin/service/MemberService.java
+++ b/backend/sin/src/main/java/sin/sin/service/MemberService.java
@@ -18,6 +18,7 @@ public class MemberService {
         Member foundMember = memberRepository.findById(member.getId())
             .orElseThrow(() -> new IllegalArgumentException("해당되는 유저가 없습니다!"));
 
-        return new MemberResponse(foundMember.getId(), foundMember.get_id());
+        return new MemberResponse(foundMember.getId(), foundMember.get_id(),
+            foundMember.getLevel().getSalePercent());
     }
 }

--- a/frontend/sin/src/components/Header.js
+++ b/frontend/sin/src/components/Header.js
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import { Link, useHistory } from 'react-router-dom';
+import {ACCESS_TOKEN} from "../constants/Sessionstorage";
+import findUserApi from "./api/user/FIndUserApi";
 
 const Headerwrap = styled.div``
 const Container = styled.div`width: 1050px; margin: 0 auto;`
@@ -46,6 +48,19 @@ const Header = (props) => {
         setSub(id)
     }
 
+    const [user, setUser] = useState(null);
+    const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
+
+    useEffect(() => {
+        if (!accessToken) {
+            return;
+        }
+        findUserApi(accessToken).then(userPromise => {
+            setUser(userPromise)
+        })
+    }, [accessToken]);
+
+    console.log(user)
     return (
         <Headerwrap>
             <Container>
@@ -53,9 +68,13 @@ const Header = (props) => {
                     <Usermenu className='clearfix'>
                         <Usermenuleft>item</Usermenuleft>
                         <Usermenuright>
-                            <Link to='/shop/member/join'>회원가입</Link>
-                            <Link to='/shop/member/login'>로그인</Link> / 
-                            <Link to='/shop/mypage/mypage_orderlist'>로그인중</Link>
+                            {user == null?
+                                <block><Link
+                                    to='/shop/member/join'>회원가입</Link> |
+                                    <Link to='/shop/member/login'>로그인</Link> |
+                                </block>
+                                : user.loginId +" 님 | "
+                            }
                             <Link to='/shop/board/list?id=notice'>고객센터</Link>
                         </Usermenuright>
                     </Usermenu>

--- a/frontend/sin/src/components/Home.js
+++ b/frontend/sin/src/components/Home.js
@@ -1,13 +1,13 @@
 import React,{useState,useEffect} from 'react';
 import styled from 'styled-components';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import SwiperCore, { Navigation } from "swiper";
-import "swiper/swiper.scss";
-import "swiper/components/navigation/navigation.scss";
+/*import { Swiper, SwiperSlide } from 'swiper/react';*/
+/*import SwiperCore, { Navigation } from "swiper";*/
+/*import "swiper/swiper.scss";
+import "swiper/components/navigation/navigation.scss";*/
 import axios from 'axios';
 import { BACKEND_ADDRESS } from '../constants/ADDRESS';
 
-SwiperCore.use([Navigation])
+/*SwiperCore.use([Navigation])*/
 
 
 const Homewrap = styled.div``
@@ -27,7 +27,7 @@ const Section4wrap = styled.div``
 const Section4 = styled.div`height: 300px; background: #555;`
 
 const Home = () => {
-    const [bannerImg,setBannerImg] = useState([])
+    /*const [bannerImg,setBannerImg] = useState([])
     const [section2,setSection2] = useState([])
 
     useEffect(()=>{
@@ -43,10 +43,10 @@ const Home = () => {
         }).then(res=>{
             setSection2(Section2.concat(res.data))
         })
-    },[])
+    },[])*/
     return (
         <Homewrap>
-            <ContainerSlide>
+            {/*<ContainerSlide>
                 <Row>
                     <Slide>
                         <Swiper
@@ -61,7 +61,7 @@ const Home = () => {
                         </Swiper>
                     </Slide>
                 </Row>
-            </ContainerSlide>
+            </ContainerSlide>*/}
             <Section1wrap>
                 <Container>
                     <Row>

--- a/frontend/sin/src/components/Login.js
+++ b/frontend/sin/src/components/Login.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import {Link} from 'react-router-dom';
 
 const Loginwrap = styled.div``
 const Container = styled.div`width: 1050px; margin: 0 auto;`
@@ -19,35 +19,33 @@ const Loginfooterbuttonlogin = styled.button`display: block; width: 100%; height
 const Loginfooterbuttonsignup = styled.button`display: block; width: 100%; height: 50px; color: #5f0080; font-size: 16px; font-weight: bold; box-sizing: border-box; margin-top: 10px; border: 1px solid #5f0080;`
 
 const Login = ({history}) => {
-    const move = () => {
-        history.push('/signup')
-    }
-    return(
-        <Loginwrap>
-            <Container>
-                <Row>
-                    <Logintitle>로그인</Logintitle>
-                    <Loginform>
-                        <Logininput type='text' placeholder='아이디를 입력해주세요' />
-                        <Logininput type='password' placeholder='비밀번호를 입력해주세요' />
-                        <Loginadd className='clearfix'>
-                            <Loginaddsecurity>
-                                <input type='checkbox' id='security' />
-                                <label htmlFor='security'>보안접속</label>
-                            </Loginaddsecurity>
-                            <Loginaddforget>
-                                <Link to=''>아이디 찾기</Link>/<Link to=''>비밀번호 찾기</Link>
-                            </Loginaddforget>
-                        </Loginadd>
-                        <Loginfooter>
-                            <Loginfooterbuttonlogin >로그인</Loginfooterbuttonlogin>
-                            <Loginfooterbuttonsignup onClick={move}>회원가입</Loginfooterbuttonsignup>
-                        </Loginfooter>
-                    </Loginform>
-                </Row>
-            </Container>
-        </Loginwrap>
-    )
+  return (
+      <Loginwrap>
+        <Container>
+          <Row>
+            <Logintitle>로그인</Logintitle>
+            <Loginform>
+              <Logininput type='text' placeholder='아이디를 입력해주세요'/>
+              <Logininput type='password' placeholder='비밀번호를 입력해주세요'/>
+              <Loginadd className='clearfix'>
+                <Loginaddsecurity>
+                  <input type='checkbox' id='security'/>
+                  <label htmlFor='security'>보안접속</label>
+                </Loginaddsecurity>
+                <Loginaddforget>
+                  <Link to=''>아이디 찾기</Link>/<Link to=''>비밀번호 찾기</Link>
+                </Loginaddforget>
+              </Loginadd>
+              <Loginfooter>
+                <Loginfooterbuttonlogin>로그인</Loginfooterbuttonlogin>
+                <Loginfooterbuttonsignup onClick={() => history.push(
+                    '/shop/member/join')}>회원가입</Loginfooterbuttonsignup>
+              </Loginfooter>
+            </Loginform>
+          </Row>
+        </Container>
+      </Loginwrap>
+  )
 }
 
 export default Login;

--- a/frontend/sin/src/components/Login.js
+++ b/frontend/sin/src/components/Login.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 import {Link} from 'react-router-dom';
+import loginApi from "./api/auth/LoginApi";
 
 const Loginwrap = styled.div``
 const Container = styled.div`width: 1050px; margin: 0 auto;`
@@ -19,14 +20,27 @@ const Loginfooterbuttonlogin = styled.button`display: block; width: 100%; height
 const Loginfooterbuttonsignup = styled.button`display: block; width: 100%; height: 50px; color: #5f0080; font-size: 16px; font-weight: bold; box-sizing: border-box; margin-top: 10px; border: 1px solid #5f0080;`
 
 const Login = ({history}) => {
+  const [id, setId] = useState("");
+  const [password, setPassword] = useState("");
+
+  const login = ()=>{
+    loginApi(id, password, history);
+  };
+
   return (
       <Loginwrap>
         <Container>
           <Row>
             <Logintitle>로그인</Logintitle>
             <Loginform>
-              <Logininput type='text' placeholder='아이디를 입력해주세요'/>
-              <Logininput type='password' placeholder='비밀번호를 입력해주세요'/>
+              <Logininput type='text'
+                          value={id}
+                          onChange={e => setId(e.target.value)}
+                          placeholder='아이디를 입력해주세요'/>
+              <Logininput type='password'
+                          value={password}
+                          onChange={e => setPassword(e.target.value)}
+                          placeholder='비밀번호를 입력해주세요'/>
               <Loginadd className='clearfix'>
                 <Loginaddsecurity>
                   <input type='checkbox' id='security'/>
@@ -37,7 +51,7 @@ const Login = ({history}) => {
                 </Loginaddforget>
               </Loginadd>
               <Loginfooter>
-                <Loginfooterbuttonlogin>로그인</Loginfooterbuttonlogin>
+                <Loginfooterbuttonlogin onClick={()=>login()}>로그인</Loginfooterbuttonlogin>
                 <Loginfooterbuttonsignup onClick={() => history.push(
                     '/shop/member/join')}>회원가입</Loginfooterbuttonsignup>
               </Loginfooter>

--- a/frontend/sin/src/components/Signup.js
+++ b/frontend/sin/src/components/Signup.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 
 const Signupwrap = styled.div``
@@ -27,111 +27,184 @@ const Agreeinput = styled.input`margin-right: 10px;`
 const Agreelabel = styled.label`font-size: 14px; color: #4c4c4c;`
 
 const Signup = () => {
-    return (
-        <Signupwrap>
-            <Container>
-                <Row>
-                    <Signuptitlewrap><Signuptitle>회원가입</Signuptitle></Signuptitlewrap>
-                    <Table>
-                        <tr>
-                            <Th>아이디</Th>
-                            <td><Input type='text' placeholder="6자 이상의 영문 혹은 영문과 숫자를 조합" /></td>
-                        </tr>
-                        <tr>
-                            <Th>비밀번호</Th>
-                            <td><Input type='password' placeholder="비밀번호를 입력해주세요" /></td>
-                        </tr>
-                        <tr>
-                            <Th>비밀번호 확인</Th>
-                            <td><Input type='password' placeholder="비밀번호를 한번 더 입력해주세요" /></td>
-                        </tr>
-                        <tr>
-                            <Th>이름</Th>
-                            <td><Input type='text' placeholder="이름을 입력해주새요" /></td>
-                        </tr>
-                        <tr>
-                            <Th>이메일</Th>
-                            <td><Input type='text' placeholder="예: marketkurly@kurly.com" /></td>
-                        </tr>
-                        <tr>
-                            <Th>휴대폰</Th>
-                            <td><Input type='number' placeholder="숫자만 입력해주세요" /></td>
-                        </tr>
-                        <tr>
-                            <Th>주소</Th>
-                            <td><Addressbtn>주소검색</Addressbtn></td>
-                        </tr>
-                        <tr>
-                            <Th>성별</Th>
-                            <td>
-                                <Sexradio type='radio' name='sex' id='sex1' />
-                                <Sexlabel htmlFor='sex1'>남자</Sexlabel>
-                                <Sexradio type='radio' name='sex' id='sex2' />
-                                <Sexlabel htmlFor='sex2'>여자</Sexlabel>
-                                <Sexradio type='radio' name='sex' id='sex3' />
-                                <Sexlabel htmlFor='sex3'>선택안함</Sexlabel>
-                            </td>
-                        </tr>
-                        <tr>
-                            <Th>생년월일</Th>
-                            <Birthtd>
-                                <Birthinput type='number' placeholder='YYYY' />
-                                <Birthinput type='number' placeholder='MM' />
-                                <Birthinput type='number' placeholder='DD' />
-                            </Birthtd>
-                        </tr>
-                        <tr>
-                            <Th>추가입력 사항</Th>
-                            <td>
-                                <Sexradio type='radio' name='option' id='option1' />
-                                <Sexlabel htmlFor='option1'>추천인 아이디</Sexlabel>
-                                <Sexradio type='radio' name='option' id='option2' />
-                                <Sexlabel htmlFor='option2'>참여 이벤트명</Sexlabel>
-                            </td>
-                        </tr>
-                        <Signupbot>
-                            <Signupbotth>이용약관동의</Signupbotth>
-                            <Signupbottd>
-                                <Agreediv>
-                                    <Agreeinput type='checkbox' id='agree1' />
-                                    <Agreelabel htmlFor='agree1'>전체 동의합니다</Agreelabel>
-                                </Agreediv>
-                                <Agreediv>
-                                    <Agreeinput type='checkbox' id='agree2' />
-                                    <Agreelabel htmlFor='agree2'>이용약관 동의</Agreelabel>
-                                </Agreediv>
-                                <Agreediv>
-                                    <Agreeinput type='checkbox' id='agree3' />
-                                    <Agreelabel htmlFor='agree3'>개인정보 수집.이용 동의(필수)</Agreelabel>
-                                </Agreediv>
-                                <Agreediv>
-                                    <Agreeinput type='checkbox' id='agree4' />
-                                    <Agreelabel htmlFor='agree4'>개인정보 수집.이용 동의(선택)</Agreelabel>
-                                </Agreediv>
-                                <Agreediv>
-                                    <Agreeinput type='checkbox' id='agree5' />
-                                    <Agreelabel htmlFor='agree5'>무료배송,할인쿠폰 등 혜택/정보 수신 동의</Agreelabel>
-                                </Agreediv>
-                                <Agreediv>
-                                    <Agreeinput type='checkbox' id='agree6' />
-                                    <Agreelabel htmlFor='agree6'>sms&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</Agreelabel>
-                                    <Agreeinput type='checkbox' id='agree7' />
-                                    <Agreelabel htmlFor='agree7'>이메일</Agreelabel>
-                                </Agreediv>
-                                <Agreediv>
-                                    <Agreeinput type='checkbox' id='agree8' />
-                                    <Agreelabel htmlFor='agree8'>본인은 만 14세 이상입니다.</Agreelabel>
-                                </Agreediv>
-                            </Signupbottd>
-                        </Signupbot>
-                    </Table>
-                    <Singupfooter>
-                        <Signupbutton>가입하기</Signupbutton>
-                    </Singupfooter>
-                </Row>
-            </Container>
-        </Signupwrap>
-    )
+
+  const [id, setId] = useState("");
+  const [password, setPassword] = useState("");
+  const [checkPassword, setCheckPassword] = useState("");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [gender, setGender] = useState("");
+  const [birthYear, setBirthYear] = useState("");
+  const [birthMonth, setBirthMonth] = useState("");
+  const [birthDay, setBirthDay] = useState("");
+
+  const signup = () => {
+    if (id.length && password.length && checkPassword.length && name.length
+        && email.length && phoneNumber.length && gender.length
+        && birthYear.length && birthMonth.length && birthDay.length) {
+      if (password === checkPassword) {
+        //signUpApi(email, password, nickName, props.history);
+        if(birthYear >=0 && birthMonth >=1 && birthMonth <=12 && birthDay >= 1 && birthDay <=31){
+          alert("조건 충족");
+        }
+        alert("생년월일을 올바르게 작성해 주세요");
+      } else {
+        alert("비밀번호가 일치하지 않습니다");
+      }
+    } else {
+      alert("빈칸을 다 채워주세요");
+    }
+  };
+
+  return (
+      <Signupwrap>
+        <Container>
+          <Row>
+            <Signuptitlewrap><Signuptitle>회원가입</Signuptitle></Signuptitlewrap>
+            <Table>
+              <tr>
+                <Th>아이디</Th>
+                <td><Input type='text'
+                           value={id}
+                           onChange={e => setId(e.target.value)}
+                           placeholder="6자 이상의 영문 혹은 영문과 숫자를 조합"/></td>
+              </tr>
+              <tr>
+                <Th>비밀번호</Th>
+                <td><Input type='password'
+                           value={password}
+                           onChange={e => setPassword(e.target.value)}
+                           placeholder="비밀번호를 입력해주세요"/></td>
+              </tr>
+              <tr>
+                <Th>비밀번호 확인</Th>
+                <td><Input type='password'
+                           value={checkPassword}
+                           onChange={e => setCheckPassword(e.target.value)}
+                           placeholder="비밀번호를 한번 더 입력해주세요"/>
+                </td>
+              </tr>
+              <tr>
+                <Th>이름</Th>
+                <td><Input type='text'
+                           value={name}
+                           onChange={e => setName(e.target.value)}
+                           placeholder="이름을 입력해주새요"/></td>
+              </tr>
+              <tr>
+                <Th>이메일</Th>
+                <td><Input type='text'
+                           value={email}
+                           onChange={e => setEmail(e.target.value)}
+                           placeholder="예: marketkurly@kurly.com"/>
+                </td>
+              </tr>
+              <tr>
+                <Th>휴대폰</Th>
+                <td><Input type='number'
+                           value={phoneNumber}
+                           onChange={e => setPhoneNumber(e.target.value)}
+                           placeholder="숫자만 입력해주세요"/></td>
+              </tr>
+              <tr>
+                <Th>주소</Th>
+                <td><Addressbtn>주소검색</Addressbtn></td>
+              </tr>
+              <tr>
+                <Th>성별</Th>
+                <td>
+                  <Sexradio type='radio'
+                            name='sex'
+                            value={gender}
+                            onChange={e => setGender('man')}
+                            id='sex1'/>
+                  <Sexlabel htmlFor='sex1'>남자</Sexlabel>
+                  <Sexradio type='radio'
+                            name='sex'
+                            value={gender}
+                            onChange={e => setGender('woman')}
+                            id='sex2'/>
+                  <Sexlabel htmlFor='sex2'>여자</Sexlabel>
+                  <Sexradio type='radio'
+                            name='sex'
+                            value={gender}
+                            onChange={e => setGender('none')}
+                            id='sex3'/>
+                  <Sexlabel htmlFor='sex3'>선택안함</Sexlabel>
+                </td>
+              </tr>
+              <tr>
+                <Th>생년월일</Th>
+                <Birthtd>
+                  <Birthinput type='number'
+                              value={birthYear}
+                              onChange={e => setBirthYear(e.target.value)}
+                              placeholder='YYYY'/>
+                  <Birthinput type='number'
+                              value={birthMonth}
+                              onChange={e => setBirthMonth(e.target.value)}
+                              placeholder='MM'/>
+                  <Birthinput type='number'
+                              value={birthDay}
+                              onChange={e => setBirthDay(e.target.value)}
+                              placeholder='DD'/>
+                </Birthtd>
+              </tr>
+              <tr>
+                <Th>추가입력 사항</Th>
+                <td>
+                  <Sexradio type='radio' name='option' id='option1'/>
+                  <Sexlabel htmlFor='option1'>추천인 아이디</Sexlabel>
+                  <Sexradio type='radio' name='option' id='option2'/>
+                  <Sexlabel htmlFor='option2'>참여 이벤트명</Sexlabel>
+                </td>
+              </tr>
+              <Signupbot>
+                <Signupbotth>이용약관동의</Signupbotth>
+                <Signupbottd>
+                  <Agreediv>
+                    <Agreeinput type='checkbox' id='agree1'/>
+                    <Agreelabel htmlFor='agree1'>전체 동의합니다</Agreelabel>
+                  </Agreediv>
+                  <Agreediv>
+                    <Agreeinput type='checkbox' id='agree2'/>
+                    <Agreelabel htmlFor='agree2'>이용약관 동의</Agreelabel>
+                  </Agreediv>
+                  <Agreediv>
+                    <Agreeinput type='checkbox' id='agree3'/>
+                    <Agreelabel htmlFor='agree3'>개인정보 수집.이용 동의(필수)</Agreelabel>
+                  </Agreediv>
+                  <Agreediv>
+                    <Agreeinput type='checkbox' id='agree4'/>
+                    <Agreelabel htmlFor='agree4'>개인정보 수집.이용 동의(선택)</Agreelabel>
+                  </Agreediv>
+                  <Agreediv>
+                    <Agreeinput type='checkbox' id='agree5'/>
+                    <Agreelabel htmlFor='agree5'>무료배송,할인쿠폰 등 혜택/정보 수신
+                      동의</Agreelabel>
+                  </Agreediv>
+                  <Agreediv>
+                    <Agreeinput type='checkbox' id='agree6'/>
+                    <Agreelabel
+                        htmlFor='agree6'>sms&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</Agreelabel>
+                    <Agreeinput type='checkbox' id='agree7'/>
+                    <Agreelabel htmlFor='agree7'>이메일</Agreelabel>
+                  </Agreediv>
+                  <Agreediv>
+                    <Agreeinput type='checkbox' id='agree8'/>
+                    <Agreelabel htmlFor='agree8'>본인은 만 14세 이상입니다.</Agreelabel>
+                  </Agreediv>
+                </Signupbottd>
+              </Signupbot>
+            </Table>
+            <Singupfooter>
+              <Signupbutton onClick={() => signup()}>가입하기</Signupbutton>
+            </Singupfooter>
+          </Row>
+        </Container>
+      </Signupwrap>
+  )
 }
 
 export default Signup;

--- a/frontend/sin/src/components/Signup.js
+++ b/frontend/sin/src/components/Signup.js
@@ -43,6 +43,9 @@ const Signup = (props) => {
   const [birthMonth, setBirthMonth] = useState("");
   const [birthDay, setBirthDay] = useState("");
 
+  const [checkDuplicatedId, setCheckDuplicatedId] = useState(false);
+  const [checkDuplicatedEmail, setCheckDuplicatedEmail] = useState(false);
+
   const signup = () => {
     if (id.length && password.length && checkPassword.length && name.length
         && email.length && phoneNumber.length && gender.length
@@ -50,9 +53,13 @@ const Signup = (props) => {
       if (password === checkPassword) {
         if (birthYear >= 0 && birthMonth >= 1 && birthMonth <= 12 && birthDay
             >= 1 && birthDay <= 31) {
-          const birth = birthYear + birthMonth + birthDay;
-          signUpApi(id, email, password, name, phoneNumber, gender, birth,
-              props.history);
+          if(checkDuplicatedId === true && checkDuplicatedEmail === true){
+            const birth = birthYear + birthMonth + birthDay;
+            signUpApi(id, email, password, name, phoneNumber, gender, birth,
+                props.history);
+          } else {
+            alert("아이디, 이메일 중복체크를 확인해주세요");
+          }
         } else {
           alert("생년월일을 올바르게 작성해 주세요");
         }
@@ -79,7 +86,10 @@ const Signup = (props) => {
                 <td>
                   <Button onClick={() => {
                     checkIsDuplicateId(id).then(message => {
-                      alert(message);
+                      if(message != null){
+                        setCheckDuplicatedId(true);
+                        alert(message);
+                      }
                     })
                   }}>중복확인</Button>
                 </td>
@@ -116,7 +126,10 @@ const Signup = (props) => {
                 <td>
                   <Button onClick={() => {
                     checkIsDuplicateEmail(email).then(message => {
-                      alert(message);
+                      if(message != null){
+                        setCheckDuplicatedEmail(true);
+                        alert(message);
+                      }
                     })
                   }}>중복확인</Button>
                 </td>

--- a/frontend/sin/src/components/Signup.js
+++ b/frontend/sin/src/components/Signup.js
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
+import signUpApi from "./api/auth/SingupApi";
 
 const Signupwrap = styled.div``
 const Container = styled.div`width: 1050px; margin: 0 auto;`
@@ -26,7 +27,7 @@ const Agreediv = styled.div`width: 480px; height: 40px;`
 const Agreeinput = styled.input`margin-right: 10px;`
 const Agreelabel = styled.label`font-size: 14px; color: #4c4c4c;`
 
-const Signup = () => {
+const Signup = (props) => {
 
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
@@ -44,11 +45,14 @@ const Signup = () => {
         && email.length && phoneNumber.length && gender.length
         && birthYear.length && birthMonth.length && birthDay.length) {
       if (password === checkPassword) {
-        //signUpApi(email, password, nickName, props.history);
-        if(birthYear >=0 && birthMonth >=1 && birthMonth <=12 && birthDay >= 1 && birthDay <=31){
+        if (birthYear >= 0 && birthMonth >= 1 && birthMonth <= 12 && birthDay
+            >= 1 && birthDay <= 31) {
           alert("조건 충족");
+          const birth = birthYear + birthMonth + birthDay;
+          signUpApi(id, email, password, name, phoneNumber, gender, birth, props.history);
+        } else {
+          alert("생년월일을 올바르게 작성해 주세요");
         }
-        alert("생년월일을 올바르게 작성해 주세요");
       } else {
         alert("비밀번호가 일치하지 않습니다");
       }
@@ -117,21 +121,15 @@ const Signup = () => {
                   <Sexradio type='radio'
                             name='sex'
                             value={gender}
-                            onChange={e => setGender('man')}
+                            onChange={e => setGender('Male')}
                             id='sex1'/>
                   <Sexlabel htmlFor='sex1'>남자</Sexlabel>
                   <Sexradio type='radio'
                             name='sex'
                             value={gender}
-                            onChange={e => setGender('woman')}
+                            onChange={e => setGender('FeMale')}
                             id='sex2'/>
                   <Sexlabel htmlFor='sex2'>여자</Sexlabel>
-                  <Sexradio type='radio'
-                            name='sex'
-                            value={gender}
-                            onChange={e => setGender('none')}
-                            id='sex3'/>
-                  <Sexlabel htmlFor='sex3'>선택안함</Sexlabel>
                 </td>
               </tr>
               <tr>

--- a/frontend/sin/src/components/Signup.js
+++ b/frontend/sin/src/components/Signup.js
@@ -1,6 +1,8 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
 import signUpApi from "./api/auth/SingupApi";
+import checkIsDuplicateEmail from "./api/auth/CheckIsDuplicateEmail";
+import checkIsDuplicateId from "./api/auth/CheckIsDuplicateId";
 
 const Signupwrap = styled.div``
 const Container = styled.div`width: 1050px; margin: 0 auto;`
@@ -11,6 +13,7 @@ const Table = styled.table`border-collapse: collapse; border-spacing: 0;`
 const Signuptitlewrap = styled.div`text-align: center; padding-top: 50px; padding-bottom:55px; border-bottom: 2px solid black;`
 const Signuptitle = styled.strong`font-size: 25px;`
 const Input = styled.input`width:330px; font-size: 14px; color: #333; box-sizing: border-box; padding: 0 14px; background: #fff; border: 1px solid #ccc; border-radius: 3px; height: 45px;`
+const Button = styled.button` margin-left: -140px; width:100px; font-size: 14px; color: purple; border-box; background: #fff; border: 1px solid purple; border-radius: 3px; height: 45px;`
 const Addressbtn = styled.button`width:330px; font-size: 14px; color: #5f0080; background: #fff; border: 1px solid #5f0080; border-radius: 3px; height: 45px; font-weight: bold; cursor: pointer;`
 const Th = styled.th`width:155px; font-size: 14px; text-align: left; padding: 30px 0px 20px 20px; color: #333333;`
 const Singupfooter = styled.div`padding-top: 40px;`
@@ -47,9 +50,9 @@ const Signup = (props) => {
       if (password === checkPassword) {
         if (birthYear >= 0 && birthMonth >= 1 && birthMonth <= 12 && birthDay
             >= 1 && birthDay <= 31) {
-          alert("조건 충족");
           const birth = birthYear + birthMonth + birthDay;
-          signUpApi(id, email, password, name, phoneNumber, gender, birth, props.history);
+          signUpApi(id, email, password, name, phoneNumber, gender, birth,
+              props.history);
         } else {
           alert("생년월일을 올바르게 작성해 주세요");
         }
@@ -73,6 +76,13 @@ const Signup = (props) => {
                            value={id}
                            onChange={e => setId(e.target.value)}
                            placeholder="6자 이상의 영문 혹은 영문과 숫자를 조합"/></td>
+                <td>
+                  <Button onClick={() => {
+                    checkIsDuplicateId(id).then(message => {
+                      alert(message);
+                    })
+                  }}>중복확인</Button>
+                </td>
               </tr>
               <tr>
                 <Th>비밀번호</Th>
@@ -102,6 +112,11 @@ const Signup = (props) => {
                            value={email}
                            onChange={e => setEmail(e.target.value)}
                            placeholder="예: marketkurly@kurly.com"/>
+                </td>
+                <td>
+                  <Button onClick={() => {
+                    checkIsDuplicateEmail();
+                  }}>중복확인</Button>
                 </td>
               </tr>
               <tr>

--- a/frontend/sin/src/components/Signup.js
+++ b/frontend/sin/src/components/Signup.js
@@ -115,7 +115,9 @@ const Signup = (props) => {
                 </td>
                 <td>
                   <Button onClick={() => {
-                    checkIsDuplicateEmail();
+                    checkIsDuplicateEmail(email).then(message => {
+                      alert(message);
+                    })
                   }}>중복확인</Button>
                 </td>
               </tr>

--- a/frontend/sin/src/components/api/auth/CheckIsDuplicateEmail.js
+++ b/frontend/sin/src/components/api/auth/CheckIsDuplicateEmail.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../../../constants/ADDRESS";
+
+const checkIsDuplicateEmail = (email) => {
+  return axios.get(BACKEND_ADDRESS + "/member/check/email?email="+email)
+  .then(response => response.data)
+  .catch(error => {
+    if (error.response.status === 400 || error.response.status === 404) {
+      alert("error.response.data.errorMessage");
+      return Promise.reject();
+    } else {
+      alert("이유가 뭔지 모르겠지만 실패...");
+    }
+  });
+};
+
+export default checkIsDuplicateEmail;

--- a/frontend/sin/src/components/api/auth/CheckIsDuplicateEmail.js
+++ b/frontend/sin/src/components/api/auth/CheckIsDuplicateEmail.js
@@ -7,7 +7,7 @@ const checkIsDuplicateEmail = (email) => {
   .then(response => response.data)
   .catch(error => {
     if (error.response.status === 400 || error.response.status === 404) {
-      alert("error.response.data.errorMessage");
+      alert(error.response.data.message);
       return Promise.reject();
     } else {
       alert("이유가 뭔지 모르겠지만 실패...");

--- a/frontend/sin/src/components/api/auth/CheckIsDuplicateId.js
+++ b/frontend/sin/src/components/api/auth/CheckIsDuplicateId.js
@@ -7,7 +7,7 @@ const checkIsDuplicateId = (id) => {
   .then(response => response.data)
   .catch(error => {
     if (error.response.status === 400 || error.response.status === 404) {
-      alert("error.response.data.errorMessage");
+      alert(error.response.data.message);
       return Promise.reject();
     } else {
       alert("이유가 뭔지 모르겠지만 실패...");

--- a/frontend/sin/src/components/api/auth/CheckIsDuplicateId.js
+++ b/frontend/sin/src/components/api/auth/CheckIsDuplicateId.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../../../constants/ADDRESS";
+
+const checkIsDuplicateId = (id) => {
+  return axios.get(BACKEND_ADDRESS + "/member/check/id?id="+id)
+  .then(response => response.data)
+  .catch(error => {
+    if (error.response.status === 400 || error.response.status === 404) {
+      alert("error.response.data.errorMessage");
+      return Promise.reject();
+    } else {
+      alert("이유가 뭔지 모르겠지만 실패...");
+    }
+  });
+};
+
+export default checkIsDuplicateId;

--- a/frontend/sin/src/components/api/auth/LoginApi.js
+++ b/frontend/sin/src/components/api/auth/LoginApi.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../../../constants/ADDRESS";
+import {ACCESS_TOKEN} from "../../../constants/Sessionstorage";
+
+const loginApi = (id, password, history) => {
+  const body = {
+    id: id,
+    password: password
+  };
+
+  axios.post(BACKEND_ADDRESS + "/member/login", body)
+  .then(response => {
+    if (response.status === 200) {
+      sessionStorage.setItem(ACCESS_TOKEN, response.data.token);
+      alert("로그인 되었습니다.");
+      history.push("/");
+    }
+  })
+  .catch(error => {
+    if (error.response.status === 401 || error.response.status === 400) {
+      alert("가입하지 않은 이메일이거나, 잘못된 비밀번호 입니다");
+      return Promise.reject();
+    }
+    alert("로그인 실패!");
+    history.push("/");
+  });
+};
+
+export default loginApi;

--- a/frontend/sin/src/components/api/auth/SingupApi.js
+++ b/frontend/sin/src/components/api/auth/SingupApi.js
@@ -18,7 +18,7 @@ const signUpApi = (id, email, password, name, phoneNumber, gender, birth, histor
   .then(response => {
     if (response.status === 200) {
       alert(response.data);
-      history.push("shop/member/login");
+      history.push("/shop/member/login");
     }
   })
   .catch(error => {

--- a/frontend/sin/src/components/api/auth/SingupApi.js
+++ b/frontend/sin/src/components/api/auth/SingupApi.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../../../constants/ADDRESS";
+
+const signUpApi = (id, email, password, name, phoneNumber, gender, birth, history) => {
+  const body = {
+    id: id,
+    email: email,
+    password: password,
+    name: name,
+    phone_number: phoneNumber,
+    address: "address",
+    gender: gender,
+    birth: birth
+  };
+
+  axios.post(BACKEND_ADDRESS + "/member/join", body)
+  .then(response => {
+    if (response.status === 200) {
+      alert(response.data);
+      history.push("shop/member/login");
+    }
+  })
+  .catch(error => {
+    if (error.response.status === 401 || error.response.status === 400) {
+      alert("에러발생");
+      return Promise.reject();
+    }
+    alert("뭔지 모르지만 회원가입실패?! 홈으로..");
+    history.push("/");
+  });
+};
+
+export default signUpApi;

--- a/frontend/sin/src/components/api/product/FindProductListApi.js
+++ b/frontend/sin/src/components/api/product/FindProductListApi.js
@@ -3,8 +3,8 @@ import axios from "axios";
 import {BACKEND_ADDRESS} from "../../../constants/ADDRESS";
 
 const findProductListApi = (category, list) => {
-  return category ? axios.get(BACKEND_ADDRESS + "/goods/goods_list?category=" + category).then(response => response.data)
-      : axios.get(BACKEND_ADDRESS + "/goods/goods_list?list=" + list).then(response => response.data);
+  return category ? axios.get(BACKEND_ADDRESS + "/goods/goods-list?category=" + category).then(response => response.data)
+      : axios.get(BACKEND_ADDRESS + "/goods/goods-list?list=" + list).then(response => response.data);
 };
 
 export default findProductListApi;

--- a/frontend/sin/src/components/api/user/FIndUserApi.js
+++ b/frontend/sin/src/components/api/user/FIndUserApi.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../../../constants/ADDRESS";
+
+const findUserApi = (accessToken) => {
+  const config = {
+    headers: {
+      "Authorization": "Bearer " + accessToken
+    }
+  };
+  return axios.get(BACKEND_ADDRESS + "/member/me", config)
+  .then(response => response.data)
+};
+
+export default findUserApi;

--- a/frontend/sin/src/constants/Sessionstorage.js
+++ b/frontend/sin/src/constants/Sessionstorage.js
@@ -1,0 +1,1 @@
+export const ACCESS_TOKEN = "token";


### PR DESCRIPTION
**이슈 번호**
resolved: #67 

**작업 내용**

1. 회원가입 구현 
2. 로그인 구현
4. 로그인된 상태에서 헤더에 로그인, 회원가입 버튼이 아닌 유저 아이디가 보이도록 구현(UserController#findMember)

![사진1](https://user-images.githubusercontent.com/45135492/140880556-57228a25-fb3e-4832-9383-ca9cec8031f5.JPG)

**테스트 작성 여부**

- [X] Test case

**주의 사항**
1. 회원가입에서 주소검색, 이메일 형식이 올바른지 체크, 추천인 아이디, 이용약관 선택 은 추후 추가 예정
2. 로그인 --- 아이디 찾기 비밀번호 찾기는 추후 추가 예정
3. 로그아웃은 마이페이지 작업하면서 추가예정
4. 헤더에 유저 아이디 뿐만 아니라 등급도 나올 수 있도록 추후 추가 예정